### PR TITLE
Path Switching mechanic

### DIFF
--- a/src/main/java/com/crowsofwar/avatar/client/ClientInput.java
+++ b/src/main/java/com/crowsofwar/avatar/client/ClientInput.java
@@ -77,6 +77,7 @@ public class ClientInput implements IControlsHandler {
 		addKeybinding("BendingCycleLeft", Keyboard.KEY_Z, "main");
 		addKeybinding("BendingCycleRight", Keyboard.KEY_V, "main");
 		addKeybinding("Skills", Keyboard.KEY_K, "main");
+		addKeybinding("Switch", Keyboard.KEY_R, "main");
 		addKeybinding("TransferBison", Keyboard.KEY_O, "main");
 
 		wasAbilityDown = new boolean[Abilities.all().size()];
@@ -239,6 +240,8 @@ public class ClientInput implements IControlsHandler {
 					}
 				}
 
+				boolean isSwitchPathKeyDown = AvatarControl.KEY_SWITCH.isDown();
+
 				List<Ability> allAbilities = Abilities.all();
 				for (int i = 0; i < allAbilities.size(); i++) {
 					Ability ability = allAbilities.get(i);
@@ -249,7 +252,7 @@ public class ClientInput implements IControlsHandler {
 
 					if (!conflict && mc.inGameHasFocus && mc.currentScreen == null && down && !wasAbilityDown[i]) {
 						Raytrace.Result raytrace = Raytrace.getTargetBlock(mc.player, ability.getRaytrace());
-						AvatarMod.network.sendToServer(new PacketSUseAbility(ability, raytrace));
+						AvatarMod.network.sendToServer(new PacketSUseAbility(ability, raytrace, isSwitchPathKeyDown));
 					}
 					wasAbilityDown[i] = down;
 				}

--- a/src/main/java/com/crowsofwar/avatar/client/gui/RadialMenu.java
+++ b/src/main/java/com/crowsofwar/avatar/client/gui/RadialMenu.java
@@ -227,8 +227,9 @@ public class RadialMenu extends Gui {
 			for (int i = 0; i < segments.length; i++) {
 				if (controls[i] == null) continue;
 				if (segments[i].isMouseHover(mouseX, mouseY, resolution)) {
-
-					bender.executeAbility(controls[i]);
+					boolean isSwitchPathKeyDown = AvatarControl.KEY_SWITCH.isDown();
+					
+					bender.executeAbility(controls[i], isSwitchPathKeyDown);
 					AvatarUiRenderer.fade(segments[i]);
 					playClickSound(0.8f);
 					break;

--- a/src/main/java/com/crowsofwar/avatar/common/QueuedAbilityExecutionHandler.java
+++ b/src/main/java/com/crowsofwar/avatar/common/QueuedAbilityExecutionHandler.java
@@ -41,7 +41,7 @@ public class QueuedAbilityExecutionHandler {
 				if (par.ticks <= 0 && par.data.getMiscData().getAbilityCooldown() == 0 && par
 						.data.getMiscData().getCanUseAbilities()) {
 					par.ability.execute(new AbilityContext(par.data, par.raytrace, par.ability,
-							par.entity, par.powerRating));
+							par.entity, par.powerRating, par.switchPath));
 					iterator.remove();
 				}
 			}
@@ -49,10 +49,10 @@ public class QueuedAbilityExecutionHandler {
 	}
 
 	public static void queueAbilityExecution(EntityLivingBase entity, BendingData data, Ability
-			ability, Raytrace.Result raytrace, double powerRating) {
+			ability, Raytrace.Result raytrace, double powerRating, boolean switchPath) {
 
 		abilityExecutions.add(new QueuedAbilityExecution(data.getMiscData().getAbilityCooldown(), entity, data,
-				ability, raytrace, powerRating));
+				ability, raytrace, powerRating, switchPath));
 
 	}
 
@@ -64,15 +64,17 @@ public class QueuedAbilityExecutionHandler {
 		private final Raytrace.Result raytrace;
 		private final double powerRating;
 		private int ticks;
+		private boolean switchPath;
 
 		public QueuedAbilityExecution(int ticks, EntityLivingBase entity, BendingData data,
-									  Ability ability, Raytrace.Result raytrace, double powerRating) {
+									  Ability ability, Raytrace.Result raytrace, double powerRating, boolean switchPath) {
 			this.ticks = ticks;
 			this.entity = entity;
 			this.data = data;
 			this.ability = ability;
 			this.raytrace = raytrace;
 			this.powerRating = powerRating;
+			this.switchPath = switchPath;
 		}
 
 	}

--- a/src/main/java/com/crowsofwar/avatar/common/bending/BendingAi.java
+++ b/src/main/java/com/crowsofwar/avatar/common/bending/BendingAi.java
@@ -89,7 +89,7 @@ public abstract class BendingAi extends EntityAIBase {
 	 * Executes the ability's main code (the part used for players)
 	 */
 	protected void execAbility() {
-		bender.executeAbility(ability);
+		bender.executeAbility(ability, false);
 	}
 
 	/**

--- a/src/main/java/com/crowsofwar/avatar/common/bending/air/AbilityAirGust.java
+++ b/src/main/java/com/crowsofwar/avatar/common/bending/air/AbilityAirGust.java
@@ -58,8 +58,8 @@ public class AbilityAirGust extends Ability {
 			gust.setVelocity(look.times(25));
 			gust.setPosition(Vector.getLookRectangular(entity).plus(Vector.getEntityPos(entity).withY(entity.getEyeHeight() + entity.getEntityBoundingBox().minY)));
 			gust.setOwner(entity);
-			gust.setDestroyProjectiles(ctx.isMasterLevel(FIRST));
-			gust.setAirGrab(ctx.isMasterLevel(SECOND));
+			gust.setDestroyProjectiles(ctx.isDynamicMasterLevel(FIRST));
+			gust.setAirGrab(ctx.isDynamicMasterLevel(SECOND));
 			gust.setAbility(this);
 
 			world.spawnEntity(gust);

--- a/src/main/java/com/crowsofwar/avatar/common/bending/fire/AbilityLightFire.java
+++ b/src/main/java/com/crowsofwar/avatar/common/bending/fire/AbilityLightFire.java
@@ -74,7 +74,7 @@ public class AbilityLightFire extends Ability {
 				double chance = 20 * ctx.getLevel() + 40;
 				chance += ctx.getPowerRating() / 10;
 
-				if (ctx.isMasterLevel(AbilityTreePath.FIRST)) {
+				if (ctx.isDynamicMasterLevel(AbilityTreePath.FIRST)) {
 
 					int yaw = (int) floor((ctx.getBenderEntity().rotationYaw * 8 / 360) + 0.5) & 7;
 					int x = 0, z = 0;
@@ -90,7 +90,7 @@ public class AbilityLightFire extends Ability {
 						ctx.getAbilityData().addXp(SKILLS_CONFIG.litFire);
 					}
 
-				} else if (ctx.isMasterLevel(AbilityTreePath.SECOND)) {
+				} else if (ctx.isDynamicMasterLevel(AbilityTreePath.SECOND)) {
 
 					if (spawnFire(world, blockPos, ctx, true, chance)) {
 						spawnFire(world, blockPos.add(1, 0, 0), ctx, false, 100);

--- a/src/main/java/com/crowsofwar/avatar/common/bending/water/AbilityWaterArc.java
+++ b/src/main/java/com/crowsofwar/avatar/common/bending/water/AbilityWaterArc.java
@@ -110,12 +110,12 @@ public class AbilityWaterArc extends Ability {
 				gravity = 7;
 				size = 0.6F;
 			}
-			if (ctx.isMasterLevel(AbilityData.AbilityTreePath.SECOND)) {
+			if (ctx.isDynamicMasterLevel(AbilityData.AbilityTreePath.SECOND)) {
 				damageMult = 3F;
 				gravity = 3;
 				size = 0.4F;
 			}
-			if (ctx.isMasterLevel(AbilityData.AbilityTreePath.FIRST)) {
+			if (ctx.isDynamicMasterLevel(AbilityData.AbilityTreePath.FIRST)) {
 				gravity = 9.81F;
 				size = 0.5F;
 			}
@@ -124,7 +124,7 @@ public class AbilityWaterArc extends Ability {
 
 				removeExisting(ctx);
 
-				if (ctx.isMasterLevel(AbilityData.AbilityTreePath.FIRST)) {
+				if (ctx.isDynamicMasterLevel(AbilityData.AbilityTreePath.FIRST)) {
 					EntityWaterArc water = new EntityWaterArc(world);
 
 					if (comboNumber == 0) {
@@ -176,7 +176,7 @@ public class AbilityWaterArc extends Ability {
 					water.setDamageMult(damageMult);
 					water.setSize(size);
 					water.setBehavior(new WaterArcBehavior.PlayerControlled());
-					water.isSpear(ctx.isMasterLevel(AbilityData.AbilityTreePath.SECOND));
+					water.isSpear(ctx.isDynamicMasterLevel(AbilityData.AbilityTreePath.SECOND));
 					water.setGravity(gravity);
 					water.setAbility(this);
 					world.spawnEntity(water);

--- a/src/main/java/com/crowsofwar/avatar/common/controls/AvatarControl.java
+++ b/src/main/java/com/crowsofwar/avatar/common/controls/AvatarControl.java
@@ -40,6 +40,7 @@ public class AvatarControl {
 		KEY_BENDING_CYCLE_LEFT,
 		KEY_BENDING_CYCLE_RIGHT,
 		KEY_SKILLS,
+		KEY_SWITCH,
 		KEY_TRANSFER_BISON,
 		CONTROL_LEFT_CLICK,
 		CONTROL_RIGHT_CLICK,
@@ -71,6 +72,7 @@ public class AvatarControl {
 		KEY_BENDING_CYCLE_LEFT = new AvatarControl("avatar.BendingCycleLeft", true);
 		KEY_BENDING_CYCLE_RIGHT = new AvatarControl("avatar.BendingCycleRight", true);
 		KEY_SKILLS = new AvatarControl("avatar.Skills", true);
+		KEY_SWITCH = new AvatarControl("avatar.Switch", true);
 		KEY_TRANSFER_BISON = new AvatarControl("avatar.TransferBison", true);
 		CONTROL_LEFT_CLICK = new AvatarControl("LeftClick", false);
 		CONTROL_RIGHT_CLICK = new AvatarControl("RightClick", false);

--- a/src/main/java/com/crowsofwar/avatar/common/data/Bender.java
+++ b/src/main/java/com/crowsofwar/avatar/common/data/Bender.java
@@ -178,11 +178,11 @@ public abstract class Bender {
 	 * In certain conditions, other action might be taken; e.g. on client, send a packet to the
 	 * server to execute the ability.
 	 */
-	public void executeAbility(Ability ability) {
+	public void executeAbility(Ability ability, boolean switchPath) {
 
 		Raytrace.Result raytrace = Raytrace.getTargetBlock(getEntity(),
 				ability.getRaytrace());
-		executeAbility(ability, raytrace);
+		executeAbility(ability, raytrace, switchPath);
 
 	}
 
@@ -192,7 +192,7 @@ public abstract class Bender {
 	 *
 	 * @see #executeAbility(Ability)
 	 */
-	public void executeAbility(Ability ability, Raytrace.Result raytrace) {
+	public void executeAbility(Ability ability, Raytrace.Result raytrace, boolean switchPath) {
 		if (!getWorld().isRemote) {
 			// Server-side : Execute the ability
 
@@ -207,7 +207,7 @@ public abstract class Bender {
 					if (data.getMiscData().getCanUseAbilities()) {
 
 						AbilityContext abilityCtx = new AbilityContext(data, raytrace, ability,
-								entity, powerRating);
+								entity, powerRating, switchPath);
 
 						ability.execute(abilityCtx);
 						data.getMiscData().setAbilityCooldown(ability.getCooldown(abilityCtx));
@@ -219,7 +219,7 @@ public abstract class Bender {
 
 				} else {
 					QueuedAbilityExecutionHandler.queueAbilityExecution(entity, data, ability,
-							raytrace, powerRating);
+							raytrace, powerRating, switchPath);
 				}
 			} else {
 				sendMessage("avatar.abilityLocked");

--- a/src/main/java/com/crowsofwar/avatar/common/data/ctx/AbilityContext.java
+++ b/src/main/java/com/crowsofwar/avatar/common/data/ctx/AbilityContext.java
@@ -31,19 +31,22 @@ public class AbilityContext extends BendingContext {
 
 	private final Ability ability;
 	private final double powerRating;
+	private final boolean switchPath;
 
-	public AbilityContext(BendingData data, Result raytrace, Ability ability, EntityLivingBase
-			entity, double powerRating) {
+	public AbilityContext(BendingData data, Result raytrace, Ability ability, EntityLivingBase entity,
+			double powerRating, boolean switchPath) {
 		super(data, entity, raytrace);
 		this.ability = ability;
 		this.powerRating = powerRating;
+		this.switchPath = switchPath;
 	}
 
-	public AbilityContext(BendingData data, EntityLivingBase entity, Bender bender, Result raytrace,
-						  Ability ability, double powerRating) {
+	public AbilityContext(BendingData data, EntityLivingBase entity, Bender bender, Result raytrace, Ability ability,
+			double powerRating, boolean switchPath) {
 		super(data, entity, bender, raytrace);
 		this.ability = ability;
 		this.powerRating = powerRating;
+		this.switchPath = switchPath;
 	}
 
 	public AbilityData getAbilityData() {
@@ -58,11 +61,38 @@ public class AbilityContext extends BendingContext {
 		return getAbilityData().getPath();
 	}
 
+	/*
+	 * Same as getPath(), but accounts for a dynamic change
+	 */
+	public AbilityTreePath getDynamicPath() {
+		AbilityTreePath dynPath;
+		AbilityTreePath currentPath = getPath();
+		if (switchPath) {
+			if (currentPath == AbilityTreePath.FIRST) {
+				dynPath = AbilityTreePath.SECOND;
+			} else if (currentPath == AbilityTreePath.SECOND) {
+				dynPath = AbilityTreePath.FIRST;
+			} else {
+				dynPath = AbilityTreePath.MAIN;
+			}
+		} else {
+			dynPath = currentPath;
+		}
+		return dynPath;
+	}
+
 	/**
 	 * Returns true if ability is on level 4 and has selected that path.
 	 */
 	public boolean isMasterLevel(AbilityTreePath path) {
 		return getLevel() == 3 && getPath() == path;
+	}
+
+	/**
+	 * Same as isMasterLevel(), but accounts for a dynamic change
+	 */
+	public boolean isDynamicMasterLevel(AbilityTreePath path) {
+		return getLevel() == 3 && getDynamicPath() == path;
 	}
 
 	/**
@@ -73,7 +103,8 @@ public class AbilityContext extends BendingContext {
 	}
 
 	/**
-	 * Gets the power rating, but in the range 0.25 to 2.0 for convenience in damage calculations.
+	 * Gets the power rating, but in the range 0.25 to 2.0 for convenience in damage
+	 * calculations.
 	 * <ul>
 	 * <li>-100 power rating gives 0.25; damage would be 1/4 of normal</li>
 	 * <li>0 power rating gives 1; damage would be the same as normal</li>

--- a/src/main/java/com/crowsofwar/avatar/common/data/ctx/PlayerBender.java
+++ b/src/main/java/com/crowsofwar/avatar/common/data/ctx/PlayerBender.java
@@ -145,13 +145,13 @@ public class PlayerBender extends Bender {
 	}
 
 	@Override
-	public void executeAbility(Ability ability, Raytrace.Result raytrace) {
+	public void executeAbility(Ability ability, Raytrace.Result raytrace, boolean switchPath) {
 		if (getWorld().isRemote) {
 
-			AvatarMod.network.sendToServer(new PacketSUseAbility(ability, raytrace));
+			AvatarMod.network.sendToServer(new PacketSUseAbility(ability, raytrace, switchPath));
 
 		} else {
-			super.executeAbility(ability, raytrace);
+			super.executeAbility(ability, raytrace, switchPath);
 		}
 	}
 

--- a/src/main/java/com/crowsofwar/avatar/common/entity/mob/EntitySkyBison.java
+++ b/src/main/java/com/crowsofwar/avatar/common/entity/mob/EntitySkyBison.java
@@ -758,7 +758,7 @@ public class EntitySkyBison extends EntityBender implements IEntityOwnable, IInv
 
 	private void onLiftoff() {
 		if (!isEatingGrass()) {
-			getBender().executeAbility(Abilities.get("air_jump"));
+			getBender().executeAbility(Abilities.get("air_jump"), false);
 			StatusControl.AIR_JUMP.execute(new BendingContext(getData(), this, getBender(), new
 					Raytrace.Result()));
 			getData().removeStatusControl(StatusControl.AIR_JUMP);

--- a/src/main/java/com/crowsofwar/avatar/common/network/PacketHandlerServer.java
+++ b/src/main/java/com/crowsofwar/avatar/common/network/PacketHandlerServer.java
@@ -128,7 +128,7 @@ public class PacketHandlerServer implements IPacketHandler {
 		Bender bender = Bender.get(player);
 		if (bender != null) {
 
-			bender.executeAbility(packet.getAbility(), packet.getRaytrace());
+			bender.executeAbility(packet.getAbility(), packet.getRaytrace(), packet.getSwitchpath());
 
 			// Send analytics
 			String abilityName = packet.getAbility().getName();

--- a/src/main/java/com/crowsofwar/avatar/common/network/packets/PacketSUseAbility.java
+++ b/src/main/java/com/crowsofwar/avatar/common/network/packets/PacketSUseAbility.java
@@ -36,13 +36,15 @@ public class PacketSUseAbility extends AvatarPacket<PacketSUseAbility> {
 
 	private Ability ability;
 	private Raytrace.Result raytrace;
+	private boolean switchPath;
 
 	public PacketSUseAbility() {
 	}
 
-	public PacketSUseAbility(Ability ability, Raytrace.Result raytrace) {
+	public PacketSUseAbility(Ability ability, Raytrace.Result raytrace, boolean switchPath) {
 		this.ability = ability;
 		this.raytrace = raytrace;
+		this.switchPath = switchPath;
 	}
 
 	@Override
@@ -52,12 +54,14 @@ public class PacketSUseAbility extends AvatarPacket<PacketSUseAbility> {
 			throw new NullPointerException("Server sent invalid ability over network: ID " + ability);
 		}
 		raytrace = Raytrace.Result.fromBytes(buf);
+		switchPath = buf.readBoolean();
 	}
 
 	@Override
 	public void avatarToBytes(ByteBuf buf) {
 		GoreCoreByteBufUtil.writeString(buf, ability.getName());
 		raytrace.toBytes(buf);
+		buf.writeBoolean(switchPath);
 	}
 
 	@Override
@@ -67,6 +71,10 @@ public class PacketSUseAbility extends AvatarPacket<PacketSUseAbility> {
 
 	public Ability getAbility() {
 		return ability;
+	}
+
+	public boolean getSwitchpath(){
+		return switchPath;
 	}
 
 	public Raytrace.Result getRaytrace() {

--- a/src/main/resources/assets/avatarmod/lang/en_us.lang
+++ b/src/main/resources/assets/avatarmod/lang/en_us.lang
@@ -11,6 +11,7 @@ avatar.Bend=Use Bending
 avatar.BendingCycleLeft=Cycle Bending Left
 avatar.BendingCycleRight=Cycle Bending Right
 avatar.Skills=Skills Menu
+avatar.Switch=Switch Path
 avatar.TransferBison=Confirm Bison Transfer
 
 avatar.combustionbending=§8§lCombustionbending

--- a/src/main/resources/assets/avatarmod/lang/fr_fr.lang
+++ b/src/main/resources/assets/avatarmod/lang/fr_fr.lang
@@ -10,6 +10,7 @@ avatar.Bend=Utiliser la Maîtrise
 avatar.BendingCycleLeft=Cycle de Maîtrises Gauche
 avatar.BendingCycleRight=Cycle de Maîtrises Droite
 avatar.Skills=Menu de Compétences
+avatar.Switch=Changer de spécialisation
 avatar.TransferBison=Confirmer le transfert de Bison
 
 avatar.earthbending=Maîtrise de la Terre


### PR DESCRIPTION
This PR adds the ability to dynamically switch between lvl4 paths for some abilities.
The switch in question is activated when a key (R by default), is held down while bending.

Getting the actual move to execute for compatible abilities can be done through AbilityContext#getDynamicPath / AbilityContext#isDynamicMasterPath. Those will return the 2nd (locked) lvl4 path if the switch was activated.

Currently only the air gust has been modified to work.

Langfiles will need to be updated.