### PR TITLE
Particle fixes + small improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,15 @@ eclipse
 run
 ignore*
 secrets.properties
+
+# run
+saves
+logs
+config
+crash-reports
+asm
+mods
+resourcepacks
+options.txt
+usercache.json
+usernamecache.json

--- a/src/main/java/com/crowsofwar/avatar/bending/bending/earth/statctrls/StatCtrlThrowBlock.java
+++ b/src/main/java/com/crowsofwar/avatar/bending/bending/earth/statctrls/StatCtrlThrowBlock.java
@@ -17,20 +17,26 @@
 
 package com.crowsofwar.avatar.bending.bending.earth.statctrls;
 
+import static com.crowsofwar.avatar.util.data.StatusControlController.PLACE_BLOCK;
+
 import com.crowsofwar.avatar.bending.bending.earth.AbilityEarthControl;
 import com.crowsofwar.avatar.client.controls.AvatarControl;
+import com.crowsofwar.avatar.entity.AvatarEntity;
+import com.crowsofwar.avatar.entity.EntityFloatingBlock;
+import com.crowsofwar.avatar.entity.data.FloatingBlockBehavior;
+import com.crowsofwar.avatar.util.Raytrace;
 import com.crowsofwar.avatar.util.data.AbilityData;
 import com.crowsofwar.avatar.util.data.BendingData;
 import com.crowsofwar.avatar.util.data.StatusControl;
 import com.crowsofwar.avatar.util.data.ctx.BendingContext;
-import com.crowsofwar.avatar.entity.AvatarEntity;
-import com.crowsofwar.avatar.entity.EntityFloatingBlock;
-import com.crowsofwar.avatar.entity.data.FloatingBlockBehavior;
 import com.crowsofwar.gorecore.util.Vector;
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.world.World;
+import com.google.common.base.Predicates;
 
-import static com.crowsofwar.avatar.util.data.StatusControlController.PLACE_BLOCK;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.util.math.RayTraceResult;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
 
 /**
  * @author CrowsOfWar
@@ -53,7 +59,6 @@ public class StatCtrlThrowBlock extends StatusControl {
 				entity);
 
 		if (floating != null) {
-
 			float yaw = (float) Math.toRadians(entity.rotationYaw);
 			float pitch = (float) Math.toRadians(entity.rotationPitch);
 
@@ -68,8 +73,24 @@ public class StatCtrlThrowBlock extends StatusControl {
 			if (abilityData.isMasterPath(AbilityData.AbilityTreePath.SECOND))
 				forceMult += 30;
 
-			Vector lookDir = Vector.toRectangular(yaw, pitch);
-			floating.setVelocity(lookDir.times(forceMult));
+			Vector direction;
+			Vec3d look = entity.getLook(1.0F);
+			Vec3d pos = entity.getPositionEyes(1.0F);
+			
+			//Drillgon200: Raytrace from the bender's line of sight and if it hit anything, use the vector from the 
+			//block to the hit point for the motion vector rather than the look vector. This improves accuracy when the
+			//block isn't directly in front of the bender.
+			RayTraceResult r = Raytrace.rayTrace(world, pos, look.scale(75).add(pos), 0, false, true, false, 
+					Entity.class, e -> e instanceof EntityFloatingBlock || e == entity);
+			
+			if(r != null && r.hitVec != null){
+				Vec3d dir = r.hitVec.subtract(floating.getPositionVector()).normalize();
+				direction = new Vector(dir.x, dir.y, dir.z);
+			} else {
+				direction = Vector.toRectangular(yaw, pitch);
+			}
+			
+			floating.setVelocity(direction.times(forceMult));
 			floating.setBehavior(new FloatingBlockBehavior.Thrown());
 
 			data.removeStatusControl(PLACE_BLOCK);

--- a/src/main/java/com/crowsofwar/avatar/bending/bending/fire/statctrls/StatCtrlThrowFireball.java
+++ b/src/main/java/com/crowsofwar/avatar/bending/bending/fire/statctrls/StatCtrlThrowFireball.java
@@ -64,6 +64,7 @@ public class StatCtrlThrowFireball extends StatusControl {
 
 			Vector vel = lookPos.minus(Vector.getEntityPos(fireball));
 
+			//Drillgon200: Why deal with orbit ids when there's already two other ids you can organize them by?
 			if (!fireballs.isEmpty()) {
 				fireballs = fireballs.stream().filter(fireball1 -> !(fireball1.getBehavior() instanceof FireballBehavior.Thrown
 						|| fireball1.getBehavior() instanceof AbilityFireball.FireballOrbitController)).collect(Collectors.toList());

--- a/src/main/java/com/crowsofwar/avatar/client/particle/ParticleBuilder.java
+++ b/src/main/java/com/crowsofwar/avatar/client/particle/ParticleBuilder.java
@@ -4,7 +4,9 @@ package com.crowsofwar.avatar.client.particle;
 import com.crowsofwar.avatar.AvatarInfo;
 import com.crowsofwar.avatar.AvatarLog;
 import com.crowsofwar.avatar.AvatarMod;
+import com.crowsofwar.avatar.client.particles.newparticles.FlashParticleBatchRenderer;
 import com.crowsofwar.avatar.client.particles.newparticles.ParticleAvatar;
+import com.crowsofwar.avatar.client.particles.newparticles.ParticleFlash;
 import com.crowsofwar.avatar.client.particles.newparticles.behaviour.ParticleAvatarBehaviour;
 import com.crowsofwar.avatar.bending.bending.Ability;
 import com.crowsofwar.avatar.bending.bending.BendingStyle;
@@ -895,8 +897,11 @@ public final class ParticleBuilder {
 		particle.setTargetPosition(tx, ty, tz);
 		particle.setTargetEntity(target);
 
-
-		net.minecraft.client.Minecraft.getMinecraft().effectRenderer.addEffect(particle);
+		if(particle instanceof ParticleFlash){
+			FlashParticleBatchRenderer.addParticle((ParticleFlash) particle);
+		} else {
+			net.minecraft.client.Minecraft.getMinecraft().effectRenderer.addEffect(particle);
+		}
 
 		reset();
 	}

--- a/src/main/java/com/crowsofwar/avatar/client/particles/newparticles/FlashParticleBatchRenderer.java
+++ b/src/main/java/com/crowsofwar/avatar/client/particles/newparticles/FlashParticleBatchRenderer.java
@@ -1,0 +1,140 @@
+package com.crowsofwar.avatar.client.particles.newparticles;
+
+import static com.crowsofwar.avatar.config.ConfigClient.CLIENT_CONFIG;
+
+import java.util.ArrayDeque;
+import java.util.Iterator;
+import java.util.Queue;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL20;
+
+import com.crowsofwar.avatar.AvatarInfo;
+import com.google.common.collect.Queues;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.particle.Particle;
+import net.minecraft.client.renderer.ActiveRenderInfo;
+import net.minecraft.client.renderer.BufferBuilder;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.GlStateManager.DestFactor;
+import net.minecraft.client.renderer.GlStateManager.SourceFactor;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.entity.Entity;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.client.event.RenderWorldLastEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
+
+//Drillgon200: Like the vanilla particle manager, but supports more gl states.
+@SideOnly(Side.CLIENT)
+@Mod.EventBusSubscriber(value = Side.CLIENT, modid = AvatarInfo.MOD_ID)
+public class FlashParticleBatchRenderer {
+
+	private static final ResourceLocation PARTICLE_TEXTURES = new ResourceLocation("minecraft", "textures/particle/particles.png");
+	
+	@SuppressWarnings("unchecked")
+	private static ArrayDeque<ParticleFlash>[] particles = new ArrayDeque[2];
+	
+	private static final Queue<ParticleFlash> queue = Queues.<ParticleFlash>newArrayDeque();
+	
+	static {
+		for(int i = 0; i < particles.length; i ++){
+			particles[i] = Queues.newArrayDeque();
+		}
+	}
+	
+	public static void addParticle(ParticleFlash p){
+		if(p != null)
+			queue.add(p);
+	}
+	
+	public static void updateParticles(){
+		if(Minecraft.getMinecraft().world == null || Minecraft.getMinecraft().isGamePaused())
+			return;
+		for(ArrayDeque<ParticleFlash> a : particles){
+			Iterator<ParticleFlash> itr = a.iterator();
+			while(itr.hasNext()){
+				ParticleFlash p = itr.next();
+				p.onUpdate();
+				if(!p.isAlive()){
+					itr.remove();
+				}
+			}
+		}
+		
+		if(!queue.isEmpty()){
+			for (ParticleFlash particle = queue.poll(); particle != null; particle = queue.poll())
+            {
+                int glow = particle.glow ? 1 : 0;
+                if(particles[glow].size() > 16384)
+                	particles[glow].removeFirst();
+                particles[glow].add(particle);
+            }
+		}
+	}
+	
+	public static void renderParticles(Entity entityIn, float partialTicks){
+		float f = ActiveRenderInfo.getRotationX();
+        float f1 = ActiveRenderInfo.getRotationZ();
+        float f2 = ActiveRenderInfo.getRotationYZ();
+        float f3 = ActiveRenderInfo.getRotationXY();
+        float f4 = ActiveRenderInfo.getRotationXZ();
+        Particle.interpPosX = entityIn.lastTickPosX + (entityIn.posX - entityIn.lastTickPosX) * (double)partialTicks;
+        Particle.interpPosY = entityIn.lastTickPosY + (entityIn.posY - entityIn.lastTickPosY) * (double)partialTicks;
+        Particle.interpPosZ = entityIn.lastTickPosZ + (entityIn.posZ - entityIn.lastTickPosZ) * (double)partialTicks;
+        Particle.cameraViewDir = entityIn.getLook(partialTicks);
+        GlStateManager.enableBlend();
+        GlStateManager.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+        GlStateManager.alphaFunc(GL11.GL_GREATER, 0.003921569F);
+        GlStateManager.depthMask(false);
+        
+        if(CLIENT_CONFIG.particleSettings.releaseShaderOnFlashParticleRender && GL11.glGetInteger(GL20.GL_CURRENT_PROGRAM) != 0){
+        	GL20.glUseProgram(0);
+        }
+        
+        Minecraft.getMinecraft().renderEngine.bindTexture(PARTICLE_TEXTURES);
+        
+        for(int i = 0; i < particles.length; i ++){
+        	if(i == 0) {
+        		GlStateManager.blendFunc(SourceFactor.SRC_ALPHA, DestFactor.ONE_MINUS_SRC_ALPHA);
+        	} else if(i == 1) {
+        		GlStateManager.blendFunc(SourceFactor.SRC_ALPHA, DestFactor.ONE);
+        	}
+        	
+        	if (CLIENT_CONFIG.particleSettings.voxelFlashParticles) {
+                GlStateManager.blendFunc(GlStateManager.SourceFactor.SRC_COLOR, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+            }
+        	
+        	GlStateManager.color(1.0F, 1.0F, 1.0F, 1.0F);
+            Tessellator tessellator = Tessellator.getInstance();
+            BufferBuilder bufferbuilder = tessellator.getBuffer();
+            bufferbuilder.begin(7, DefaultVertexFormats.PARTICLE_POSITION_TEX_COLOR_LMAP);
+            particles[i].forEach(particle -> particle.renderParticle(bufferbuilder, entityIn, partialTicks, f, f4, f1, f2, f3));
+            
+            tessellator.draw();
+        }
+		
+		GlStateManager.depthMask(true);
+		GlStateManager.blendFunc(SourceFactor.SRC_ALPHA, DestFactor.ONE_MINUS_SRC_ALPHA);
+        GlStateManager.disableBlend();
+        GlStateManager.alphaFunc(GL11.GL_GREATER, 0.1F);
+	}
+	
+	@SubscribeEvent
+	public static void renderLast(RenderWorldLastEvent event){
+		renderParticles(Minecraft.getMinecraft().getRenderViewEntity(), event.getPartialTicks());
+	}
+	
+	@SubscribeEvent
+	public static void clientTick(ClientTickEvent event){
+		if(event.phase == Phase.START){
+			updateParticles();
+		}
+	}
+}

--- a/src/main/java/com/crowsofwar/avatar/client/particles/newparticles/FlashParticleBatchRenderer.java
+++ b/src/main/java/com/crowsofwar/avatar/client/particles/newparticles/FlashParticleBatchRenderer.java
@@ -39,7 +39,7 @@ public class FlashParticleBatchRenderer {
 	private static final ResourceLocation PARTICLE_TEXTURES = new ResourceLocation("minecraft", "textures/particle/particles.png");
 	
 	@SuppressWarnings("unchecked")
-	private static ArrayDeque<ParticleFlash>[] particles = new ArrayDeque[2];
+	public static ArrayDeque<ParticleFlash>[] particles = new ArrayDeque[2];
 	
 	private static final Queue<ParticleFlash> queue = Queues.<ParticleFlash>newArrayDeque();
 	

--- a/src/main/java/com/crowsofwar/avatar/client/particles/newparticles/ParticleFire.java
+++ b/src/main/java/com/crowsofwar/avatar/client/particles/newparticles/ParticleFire.java
@@ -35,6 +35,11 @@ public class ParticleFire extends ParticleAvatar {
 			event.getMap().registerSprite(array);
 		}
 	}
+	
+	@Override
+	public boolean shouldDisableDepth() {
+		return true;
+	}
 
 	@Override
 	public void onUpdate() {

--- a/src/main/java/com/crowsofwar/avatar/client/particles/newparticles/ParticleFlash.java
+++ b/src/main/java/com/crowsofwar/avatar/client/particles/newparticles/ParticleFlash.java
@@ -1,18 +1,23 @@
 package com.crowsofwar.avatar.client.particles.newparticles;
 
+import com.crowsofwar.avatar.bending.bending.BendingStyle;
 import com.crowsofwar.avatar.bending.bending.air.Airbending;
 import com.crowsofwar.avatar.bending.bending.fire.Firebending;
+import com.crowsofwar.avatar.config.ConfigClient.ParticleRenderSettings;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
-import net.minecraft.entity.Entity;
+import net.minecraft.entity.Entity ;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Loader;
 import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL20;
 
 import static com.crowsofwar.avatar.config.ConfigClient.CLIENT_CONFIG;
 
@@ -36,7 +41,6 @@ public class ParticleFlash extends ParticleAvatar /*implements IGlowingEntity*/ 
         this.particleMaxAge = 6;
     }
 
-
     @Override
     public boolean shouldDisableDepth() {
         return true;
@@ -48,28 +52,35 @@ public class ParticleFlash extends ParticleAvatar /*implements IGlowingEntity*/ 
             return 3;
         return 0;
     }
+    
+    @Override
+    public void setGlowing(boolean glow) {
+    	super.setGlowing(glow || element instanceof Firebending);
+    }
 
     @Override
     public void drawParticle(BufferBuilder buffer, Entity entityIn, float partialTicks, float rotationX, float rotationZ, float rotationYZ, float rotationXY, float rotationXZ) {
 
-        GlStateManager.pushMatrix();
-        GlStateManager.enableBlend();
-        GlStateManager.disableAlpha();
-
-        if (CLIENT_CONFIG.particleSettings.layeredOverWaterFlashParticles)
+        /*if (CLIENT_CONFIG.particleSettings.layeredOverWaterFlashParticles) {
+            if(GL11.glGetInteger(GL20.GL_CURRENT_PROGRAM) != 0)
+                GL20.glUseProgram(0);
             Minecraft.getMinecraft().renderEngine.bindTexture(PARTICLE_TEXTURES);
+        }
 
-        if (element instanceof Firebending || glow) {
+        if (glow) {
             GlStateManager.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE);
+        } else {
+            GlStateManager.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
         }
 
         if (CLIENT_CONFIG.particleSettings.voxelFlashParticles) {
             GlStateManager.blendFunc(GlStateManager.SourceFactor.SRC_COLOR, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
-        }
+        }*/
 
-        OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240f, 240f);
+        //Drillgon200: What's the point of setting lightmap here when you just set it as a vertex attribute again?
+        //OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240f, 240f);
 
-        float f4;
+        float f4 = 1;
         if (CLIENT_CONFIG.particleSettings.voxelFlashParticles) {
             setRBGColorF(particleRed * 0.875f, particleGreen * 0.875F, particleBlue * 0.875F);
             setAlphaF(particleAlpha * 0.9F);
@@ -78,12 +89,11 @@ public class ParticleFlash extends ParticleAvatar /*implements IGlowingEntity*/ 
             f4 = particleScale * MathHelper.sin(((float) this.particleAge + partialTicks - 1.0F) / particleMaxAge * (float) Math.PI);
         }
 
-        if (CLIENT_CONFIG.particleSettings.layeredOverWaterFlashParticles)
+        /*if (CLIENT_CONFIG.particleSettings.layeredOverWaterFlashParticles)
             if (element instanceof Airbending) {
-                particleAlpha *= 1.1F;
-                particleScale *= 0.75F;
+                GlStateManager.disableAlpha();
             }
-
+        */
         if (CLIENT_CONFIG.shaderSettings.bslActive || CLIENT_CONFIG.shaderSettings.sildursActive) {
             if (element instanceof Airbending)
                 setRBGColorF(0.95F, 0.95F, 0.95F);
@@ -112,9 +122,11 @@ public class ParticleFlash extends ParticleAvatar /*implements IGlowingEntity*/ 
         int j = i >> 16 & 65535;
         int k = i & 65535;
 
+        // buffer = Tessellator.getInstance().getBuffer();
 
-        if (CLIENT_CONFIG.particleSettings.layeredOverWaterFlashParticles)
-            buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.PARTICLE_POSITION_TEX_COLOR_LMAP);
+
+        //if (CLIENT_CONFIG.particleSettings.layeredOverWaterFlashParticles)
+       //     buffer.begin(GL11.GL_QUADS, DefaultVertexFormats.PARTICLE_POSITION_TEX_COLOR_LMAP);
         buffer.pos(f5 - rotationX * f4 - rotationXY * f4, f6 - rotationZ * f4, f7 - rotationYZ * f4 - rotationXZ * f4).tex(0.5D, 0.375D)
                 .color(this.particleRed, this.particleGreen, this.particleBlue, this.particleAlpha).lightmap(j, k).endVertex();
         buffer.pos(f5 - rotationX * f4 + rotationXY * f4, f6 + rotationZ * f4, f7 - rotationYZ * f4 + rotationXZ * f4).tex(0.5D, 0.125D)
@@ -123,10 +135,8 @@ public class ParticleFlash extends ParticleAvatar /*implements IGlowingEntity*/ 
                 .color(this.particleRed, this.particleGreen, this.particleBlue, this.particleAlpha).lightmap(j, k).endVertex();
         buffer.pos(f5 + rotationX * f4 - rotationXY * f4, f6 - rotationZ * f4, f7 + rotationYZ * f4 - rotationXZ * f4).tex(0.25D, 0.375D)
                 .color(this.particleRed, this.particleGreen, this.particleBlue, this.particleAlpha).lightmap(j, k).endVertex();
-        if (CLIENT_CONFIG.particleSettings.layeredOverWaterFlashParticles)
-            Tessellator.getInstance().draw();
-        GlStateManager.popMatrix();
-
+       // if (CLIENT_CONFIG.particleSettings.layeredOverWaterFlashParticles)
+        //    Tessellator.getInstance().draw();
     }
 
 

--- a/src/main/java/com/crowsofwar/avatar/config/ConfigClient.java
+++ b/src/main/java/com/crowsofwar/avatar/config/ConfigClient.java
@@ -227,7 +227,11 @@ public class ConfigClient {
 		public final boolean voxelFlashParticles = false;
 
 		@Load
-		public final boolean layeredOverWaterFlashParticles = false;
+		public final boolean layeredOverWaterFlashParticles = true;
+		
+		@Load
+		public final boolean releaseShaderOnFlashParticleRender = true;
+		
 	}
 
 }

--- a/src/main/java/com/crowsofwar/avatar/entity/EntityShockwave.java
+++ b/src/main/java/com/crowsofwar/avatar/entity/EntityShockwave.java
@@ -120,7 +120,7 @@ public class EntityShockwave extends EntityOffensive {
 	}
 
 	public double getParticleSpeed() {
-		return dataManager.get(SYNC_PARTICLE_SPEED);
+		return (double) dataManager.get(SYNC_PARTICLE_SPEED);
 	}
 
 	public void setParticleSpeed(float speed) {
@@ -128,7 +128,7 @@ public class EntityShockwave extends EntityOffensive {
 	}
 
 	public double getRange() {
-		return dataManager.get(SYNC_RANGE);
+		return (double) dataManager.get(SYNC_RANGE);
 	}
 
 	public void setRange(float range) {
@@ -136,7 +136,7 @@ public class EntityShockwave extends EntityOffensive {
 	}
 
 	public double getSpeed() {
-		return dataManager.get(SYNC_SPEED);
+		return (double) dataManager.get(SYNC_SPEED);
 	}
 
 	public void setSpeed(float speed) {

--- a/src/main/java/com/crowsofwar/avatar/entity/data/FloatingBlockBehavior.java
+++ b/src/main/java/com/crowsofwar/avatar/entity/data/FloatingBlockBehavior.java
@@ -235,8 +235,6 @@ public abstract class FloatingBlockBehavior extends OffensiveBehaviour {
 
 	public static class PlayerControlled extends FloatingBlockBehavior {
 
-		int ticks = 0;
-
 		public PlayerControlled() {
 		}
 
@@ -250,13 +248,18 @@ public abstract class FloatingBlockBehavior extends OffensiveBehaviour {
 			Vector eye = Vector.getEyePos(owner);
 			Vector target = forward.times(2.5).plus(eye);
 			Vec3d motion = target.minus(Vector.getEntityPos(entity)).times(0.5).toMinecraft();
-			int angle = ticks % 360;
+			int angle = (int) entity.world.getWorldTime();
 			List<EntityFloatingBlock> blocks = entity.world.getEntitiesWithinAABB(EntityFloatingBlock.class,
 					owner.getEntityBoundingBox().grow(3, 3, 3));
+			//Drillgon200: Sort the list by id so the blocks will always have the same orbit order.
+			blocks.sort((b1, b2) -> b1.getID()>b2.getID()?1:-1);
+			int index = blocks.indexOf(entity);
+			if(index < 0)
+				return this;
 			//S P I N
 			if (!blocks.isEmpty() && blocks.size() > 1) {
 				angle *= 5;
-				angle += 360 / (blocks.indexOf(entity) + 1);
+				angle += ((360 / blocks.size())*index);
 				double radians = Math.toRadians(angle);
 				double x = 2.5 * Math.cos(radians);
 				double z = 2.5 * Math.sin(radians);
@@ -266,7 +269,6 @@ public abstract class FloatingBlockBehavior extends OffensiveBehaviour {
 			}
 
 			entity.setVelocity(motion);
-			ticks++;
 			return this;
 
 		}

--- a/src/main/java/com/crowsofwar/avatar/util/AvatarUtils.java
+++ b/src/main/java/com/crowsofwar/avatar/util/AvatarUtils.java
@@ -139,7 +139,6 @@ public class AvatarUtils {
 			all_particles.addAll(layer);
 		}
 		
-		System.out.println(all_particles.size());
 		aliveParticlesCache = all_particles;
 		return aliveParticlesCache;
 	}

--- a/src/main/java/com/crowsofwar/avatar/util/AvatarUtils.java
+++ b/src/main/java/com/crowsofwar/avatar/util/AvatarUtils.java
@@ -17,13 +17,18 @@
 
 package com.crowsofwar.avatar.util;
 
+import com.crowsofwar.avatar.AvatarInfo;
 import com.crowsofwar.avatar.AvatarLog;
+import com.crowsofwar.avatar.client.particles.newparticles.FlashParticleBatchRenderer;
 import com.crowsofwar.avatar.client.particles.newparticles.ParticleAvatar;
+import com.crowsofwar.avatar.client.particles.newparticles.ParticleFlash;
 import com.crowsofwar.avatar.bending.bending.Ability;
 import com.crowsofwar.avatar.bending.bending.BendingStyle;
 import com.crowsofwar.avatar.util.damageutils.AvatarDamageSource;
 import com.crowsofwar.avatar.entity.AvatarEntity;
 import com.crowsofwar.gorecore.util.Vector;
+import com.google.common.collect.Queues;
+
 import net.minecraft.block.*;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
@@ -50,7 +55,12 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.ClientTickEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent.Phase;
 import net.minecraftforge.fml.relauncher.ReflectionHelper;
+import net.minecraftforge.fml.relauncher.Side;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -62,6 +72,7 @@ import static com.crowsofwar.avatar.AvatarLog.WarningType.INVALID_SAVE;
 import static java.lang.Math.cos;
 import static java.lang.Math.sin;
 
+@Mod.EventBusSubscriber(value = Side.CLIENT, modid = AvatarInfo.MOD_ID)
 public class AvatarUtils {
 
 	private static final DataParameter<Boolean> POWERED;
@@ -101,12 +112,43 @@ public class AvatarUtils {
 		return copy;
 	}
 
+	private static Queue<ParticleAvatar> aliveParticlesCache = null;
 
-	public static Queue<Particle> getAliveParticles() {
-		Queue<Particle> particleQueue = ReflectionHelper.getPrivateValue(ParticleManager.class, Minecraft.getMinecraft().effectRenderer, "queue",
-				"field_187241_h");
-		particleQueue = particleQueue.stream().filter(particle -> particle instanceof ParticleAvatar).collect(Collectors.toCollection(ArrayDeque::new));
-		return particleQueue;
+	/**
+	 * Don't modify the return value, it's cached.
+	 * @return The collection of all alive avatar particles
+	 */
+	@SuppressWarnings("deprecation")
+	public static Queue<ParticleAvatar> getAliveParticles() {
+		if(aliveParticlesCache != null)
+			return aliveParticlesCache;
+		ArrayDeque<Particle>[][] vanillaParticles = ReflectionHelper.getPrivateValue(ParticleManager.class, Minecraft.getMinecraft().effectRenderer, "fxLayers", "field_78876_b");
+		ArrayDeque<ParticleFlash>[] flashParticles = FlashParticleBatchRenderer.particles;
+		
+		Queue<ParticleAvatar> all_particles = new LinkedList<ParticleAvatar>();
+		for(ArrayDeque<Particle>[] layer : vanillaParticles){
+			for(ArrayDeque<Particle> depthLayer : layer){
+				for(Particle p : depthLayer){
+					if(p instanceof ParticleAvatar){
+						all_particles.add((ParticleAvatar) p);
+					}
+				}
+			}
+		}
+		for(ArrayDeque<ParticleFlash> layer : flashParticles){
+			all_particles.addAll(layer);
+		}
+		
+		System.out.println(all_particles.size());
+		aliveParticlesCache = all_particles;
+		return aliveParticlesCache;
+	}
+	
+	@SubscribeEvent
+	public static void clientTick(ClientTickEvent event){
+		if(event.phase == Phase.END){
+			aliveParticlesCache = null;
+		}
 	}
 
 	public static ParticleAvatar getParticleFromUUID(UUID id) {
@@ -688,8 +730,6 @@ public class AvatarUtils {
 
 
 	public static int getRandomNumberInRange(int min, int max) {
-		min = Math.max(min, 0);
-		max = Math.max(max, min);
 		Random r = new Random();
 		return r.nextInt((max - min) + 1) + min;
 	}

--- a/src/main/java/com/crowsofwar/avatar/util/data/AvatarPlayerData.java
+++ b/src/main/java/com/crowsofwar/avatar/util/data/AvatarPlayerData.java
@@ -120,6 +120,7 @@ public class AvatarPlayerData extends PlayerData {
 			}
 			double range = Math.sqrt(rangeSq) + 0.01;// +0.01 "just in case"
 
+			//Drillgon200: Why not just use sendToAllTracking? Might be a reason, so I won't mess with it.
 			TargetPoint targetPoint = new TargetPoint(player.dimension, player.posX, player.posY, player.posZ, range);
 			//FMLLog.info("Target Point: " + targetPoint);
 			AvatarMod.network.sendToAllAround(packet, targetPoint);

--- a/src/main/java/com/crowsofwar/avatar/util/data/BendingData.java
+++ b/src/main/java/com/crowsofwar/avatar/util/data/BendingData.java
@@ -539,6 +539,10 @@ public class BendingData {
 	public void writeToNbt(NBTTagCompound writeTo) {
 
 		// @formatter:off
+		
+		if(activeBending != null){
+			writeTo.setString("activeBending", activeBending.toString());
+		}
 
 		AvatarUtils.writeList(bendings,
 				(nbt, controllerId) -> nbt.setUniqueId("ControllerID", controllerId),
@@ -602,6 +606,10 @@ public class BendingData {
 				nbt -> nbt.getUniqueId("ControllerID"),
 				readFrom,
 				"BendingControllers");
+		
+		if(readFrom.hasKey("activeBending")){
+			setActiveBendingId(UUID.fromString(readFrom.getString("activeBending")));
+		}
 
 		AvatarUtils.readList(statusControls,
 				nbt -> StatusControlController.lookup(nbt.getInteger("Id")),


### PR DESCRIPTION
-New batch renderer for flash particles to support additive blending. Config option to disable shaders when rendering it so it still looks ok with the lighting mod. Fire particle now also disables depth so the flamethrower particles don't fail the depth test.

-Write active bending data to NBT so you don't have to switch then around again on world join

-Floating blocks rotate around the player a bit better, and they will now do a ray trace to help pick the most accurate path when thrown. Also fixed crash when the floating block isn't near the player when the spin becomes active.

-Comment questions that I'm not entirely sure about: Aren't orbit ids unnecessary when they already have two other entity ids to organize them by? Doesn't sendToAllTracking do the same thing as the tracking code in AvatarPlayerData#sendPacket?